### PR TITLE
Handle MT values as NaN to avoid string comparison

### DIFF
--- a/bin/add_c_nc.py
+++ b/bin/add_c_nc.py
@@ -26,6 +26,9 @@ def add_c_nc(score, ref):
     bl = clin_nc.new_start.values
     bc = clin_nc.new_chr.values
 
+    bc[bc=='MT'] = -1 # Treat MT chromosome as NaN values to avoid string comparison
+    bc = bc.astype(int)
+
     i, j = np.where((a[:, None] >= bl) & (a[:, None] <= bh) & (ac[:, None] == bc))
 
     cln = pd.concat(


### PR DESCRIPTION
This change ensures that MT values are
treated consistently as NaN (Not a Number),
improving code reliability
by eliminating string comparisons.

### Current:
![image](https://github.com/hyunhwan-bcm/AI_MARRVEL/assets/172427703/fe3cccc7-98d8-435e-a673-234c6fed5421)

### Improved
![image](https://github.com/hyunhwan-bcm/AI_MARRVEL/assets/172427703/759214b7-4f31-4c26-9e6b-d67d907bbb5c)
