### PR TITLE
Refactor prediction step to eliminate multiprocessing

### DIFF
--- a/bin/extraModel/generate_bivar_data.py
+++ b/bin/extraModel/generate_bivar_data.py
@@ -4,12 +4,11 @@ import numpy as np
 from glob import glob
 from tqdm import tqdm, trange
 import logging
-from multiprocessing import Pool
 from os.path import exists
 import shutil
 
 
-def process_sample(data_folder, sample_id, default_pred, labeling=False, n_thread=10):
+def process_sample(data_folder, sample_id, default_pred, labeling=False):
 
     # recessive_folder = f'{data_folder}/recessive_matrix'
     # if not os.path.exists(recessive_folder):
@@ -67,15 +66,12 @@ def process_sample(data_folder, sample_id, default_pred, labeling=False, n_threa
         for gene in gene_dict
     ]
     print(
-        f"Now starting to generate recessive feature matrix for {len(gene_dict)} genes, {feature_df.shape[0]} variants using {n_thread} threads."
+        f"Now starting to generate recessive feature matrix for {len(gene_dict)} genes, {feature_df.shape[0]} variants."
     )
-    p = Pool(processes=n_thread)
 
-    with tqdm(total=len(params)) as pbar:
-        for result in p.imap_unordered(process_gene, params):
-            pbar.update()
-    p.close()
-    p.join()
+    for param in tqdm(params):
+        process_gene(param)
+
     print("Recessive features for each gene finished, now putting together...")
 
     bivar_feature_mats = []

--- a/bin/extraModel_main.py
+++ b/bin/extraModel_main.py
@@ -16,19 +16,11 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument("-id", metavar="I", type=str, help="sample ID")
 
-parser.add_argument(
-    "-n_cpu",
-    type=int,
-    default=10,
-    help="folders containing all extended final matrices",
-)
-
 args = parser.parse_args()
 
 # st_time = time()
 # prj_name = args.project
 sample_id = args.id
-n_cpu = args.n_cpu
 
 out_folder = "conf_4Model"
 
@@ -65,7 +57,7 @@ def assign_ranking(df):
     return pred_df
 
 
-def AIM(data_folder, sample_id, n_thread):
+def AIM(data_folder, sample_id):
     feature_fn = f"{sample_id}.csv"
 
     if not os.path.exists(feature_fn):
@@ -98,7 +90,6 @@ def AIM(data_folder, sample_id, n_thread):
         sample_id=sample_id,
         default_pred=default_pred,
         labeling=False,
-        n_thread=n_thread,
     )
 
     recessive_feature_file = f"{out_folder}/recessive_matrix/{sample_id}.csv"
@@ -131,4 +122,4 @@ def AIM(data_folder, sample_id, n_thread):
 
 
 # for sample_id in tqdm(sample_folders):
-AIM(out_folder, sample_id, n_thread=n_cpu)
+AIM(out_folder, sample_id)


### PR DESCRIPTION
Previously, multiprocessing was utilized in the
prediction step, resulting in increased memory
consumption proportional
to the number of worker processes.
By refactoring the code to replace multiprocessing with a simple for loop,
memory usage has been significantly reduced.
This change not only enhances efficiency
by eliminating the overhead of virtual memory
but also accelerates runtime performance.