### PR TITLE
Filter VCFs to Exonic Regions Only

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ nextflow run .  --ref_dir <PATH_TO_REFERENCE_DIRECTORY>
                 --outdir <PATH_TO_OUTPUT_DIRECTORY>
                 --run_id [Sample Id] # Optional, default: 1
                 --ref_ver [Reference genome: hg19/hg38] # Optional, default: hg19
+                --no_filter_exonic # Optional, default: false
 ```
 
 Alternatively, the pipeline can be executed with a parameter file (yaml)

--- a/main.nf
+++ b/main.nf
@@ -38,6 +38,28 @@ process INDEX_VCF {
     """
 }
 
+process FILTER_EXONIC {
+    input:
+    path vcf
+    path tbi
+    path ref_exonic_filter_bed
+
+    output:
+    path "${params.run_id}.recode.vcf.gz"
+    path "${params.run_id}.recode.vcf.gz.tbi"
+
+    script:
+    """
+    if [ !${params.no_filter_exonic} ]; then
+        bcftools filter --regions-file ${ref_exonic_filter_bed} ${vcf} -Oz -o "${params.run_id}.recode.vcf.gz"
+        tabix -p vcf "${params.run_id}.recode.vcf.gz"
+    else
+        cp ${vcf} "${params.run_id}.recode.vcf.gz"
+        cp ${tbi} "${params.run_id}.recode.vcf.gz.tbi"
+    fi
+    """
+}
+
 process VCF_PRE_PROCESS {
     input:
     path vcf
@@ -351,7 +373,9 @@ process PREDICTION {
 workflow { 
     INDEX_VCF(params.input_vcf)
 
-    VCF_PRE_PROCESS(INDEX_VCF.out, params.chrmap)
+    FILTER_EXONIC(INDEX_VCF.out, params.ref_exonic_filter_bed)
+
+    VCF_PRE_PROCESS(FILTER_EXONIC.out, params.chrmap)
 
     REMOVE_MITO_AND_UNKOWN_CHR(VCF_PRE_PROCESS.out)
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,7 @@
 params {
     run_id = 1 
     ref_ver = "hg19"
+    no_filter_exonic = false
 
     ref_assembly =  params.ref_ver == "hg19" ? "grch37" : "grch38"
 
@@ -22,6 +23,9 @@ params {
     omim_obo = "${ref_dir}/omim_annotate/hp.obo"
     omim_genemap2 = "${ref_dir}/omim_annotate/${ref_ver}/genemap2_v2022.rds"
     omim_pheno = "${ref_dir}/omim_annotate/${ref_ver}/HPO_OMIM.tsv"
+
+    // EXONIC FILTER BED
+    ref_exonic_filter_bed = "${ref_dir}/filter_exonic/${ref_ver}.bed"
 
     // GNOMAD VCF
     ref_gnomad_genome = "${ref_dir}/filter_vep/${ref_ver}/gnomad.${ref_ver}.blacklist.genomes.vcf.gz"


### PR DESCRIPTION
### Note: You need to update data dependencies directory.
The latest directory can be found in `s3://aim-data-dependencies-2.0/`, specifically the update directory is `s3://aim-data-dependencies-2.0/filter_exonic/`


### About this PR

To prevent it from running more than days with the input vcf of WGS (Whole Genome Sequence), this changes filter to exonic regions only, based on the BED file generated with UCSC genome browser, by merging all exome probeset tracks (union function) (Mohammed provided)

This change ensures the pipeline can process within 30 minutes with the user's input of WGS.

For the previous context, see the following link: https://github.com/LiuzLab/AI_MARRVEL/pull/34

