### PR TITLE
Revert "Revert "Filter VCFs to Exonic Regions Only""

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ nextflow run .  --ref_dir <PATH_TO_REFERENCE_DIRECTORY>
                 --outdir <PATH_TO_OUTPUT_DIRECTORY>
                 --run_id [Sample Id] # Optional, default: 1
                 --ref_ver [Reference genome: hg19/hg38] # Optional, default: hg19
+                --no_filter_exonic # Optional, default: false
 ```
 
 Alternatively, the pipeline can be executed with a parameter file (yaml)

--- a/main.nf
+++ b/main.nf
@@ -38,6 +38,28 @@ process INDEX_VCF {
     """
 }
 
+process FILTER_EXONIC {
+    input:
+    path vcf
+    path tbi
+    path ref_exonic_filter_bed
+
+    output:
+    path "${params.run_id}.recode.vcf.gz"
+    path "${params.run_id}.recode.vcf.gz.tbi"
+
+    script:
+    """
+    if [ !${params.no_filter_exonic} ]; then
+        bcftools filter --regions-file ${ref_exonic_filter_bed} ${vcf} -Oz -o "${params.run_id}.recode.vcf.gz"
+        tabix -p vcf "${params.run_id}.recode.vcf.gz"
+    else
+        cp ${vcf} "${params.run_id}.recode.vcf.gz"
+        cp ${tbi} "${params.run_id}.recode.vcf.gz.tbi"
+    fi
+    """
+}
+
 process VCF_PRE_PROCESS {
     input:
     path vcf
@@ -351,7 +373,9 @@ process PREDICTION {
 workflow { 
     INDEX_VCF(params.input_vcf)
 
-    VCF_PRE_PROCESS(INDEX_VCF.out, params.chrmap)
+    FILTER_EXONIC(INDEX_VCF.out, params.ref_exonic_filter_bed)
+
+    VCF_PRE_PROCESS(FILTER_EXONIC.out, params.chrmap)
 
     REMOVE_MITO_AND_UNKOWN_CHR(VCF_PRE_PROCESS.out)
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,7 @@
 params {
     run_id = 1 
     ref_ver = "hg19"
+    no_filter_exonic = false
 
     ref_assembly =  params.ref_ver == "hg19" ? "grch37" : "grch38"
 
@@ -22,6 +23,9 @@ params {
     omim_obo = "${ref_dir}/omim_annotate/hp.obo"
     omim_genemap2 = "${ref_dir}/omim_annotate/${ref_ver}/genemap2_v2022.rds"
     omim_pheno = "${ref_dir}/omim_annotate/${ref_ver}/HPO_OMIM.tsv"
+
+    // EXONIC FILTER BED
+    ref_exonic_filter_bed = "${ref_dir}/filter_exonic/${ref_ver}.bed"
 
     // GNOMAD VCF
     ref_gnomad_genome = "${ref_dir}/filter_vep/${ref_ver}/gnomad.${ref_ver}.blacklist.genomes.vcf.gz"


### PR DESCRIPTION
Reverts hyunhwan-bcm/AI_MARRVEL#18

---

It was confirmed that the unexpected behavior with region filtering was caused by the bug of [bcftools 1.9](https://github.com/samtools/bcftools/issues/221).

The code has no problem, but just need to update the version of the bcftools higher than 1.12 or higher in Dockerfile.

So it's safe to apply the change.