### PR TITLE
Check completed - nextflow comparison with main using hg38

### DIFF
--- a/bin/add_c_nc.py
+++ b/bin/add_c_nc.py
@@ -26,9 +26,6 @@ def add_c_nc(score, ref):
     bl = clin_nc.new_start.values
     bc = clin_nc.new_chr.values
 
-    bc[bc=='MT'] = -1 # Treat MT chromosome as NaN values to avoid string comparison
-    bc = bc.astype(int)
-
     i, j = np.where((a[:, None] >= bl) & (a[:, None] <= bh) & (ac[:, None] == bc))
 
     cln = pd.concat(

--- a/bin/extraModel/generate_bivar_data.py
+++ b/bin/extraModel/generate_bivar_data.py
@@ -95,19 +95,20 @@ def process_sample(data_folder, sample_id, default_pred, labeling=False, n_threa
 
 
 def process_gene(param):
-
-    feature_names = "diffuse_Phrank_STRING,hgmdSymptomScore,omimSymMatchFlag,hgmdSymMatchFlag,clinVarSymMatchFlag,omimGeneFound,omimVarFound,hgmdGeneFound,hgmdVarFound,clinVarVarFound,clinVarGeneFound,clinvarNumP,clinvarNumLP,clinvarNumLB,clinvarNumB,dgvVarFound,decipherVarFound,curationScoreHGMD,curationScoreOMIM,curationScoreClinVar,conservationScoreDGV,omimSymptomSimScore,hgmdSymptomSimScore,GERPpp_RS,gnomadAF,gnomadAFg,LRT_score,LRT_Omega,phyloP100way_vertebrate,gnomadGeneZscore,gnomadGenePLI,gnomadGeneOELof,gnomadGeneOELofUpper,IMPACT,CADD_phred,CADD_PHRED,DANN_score,REVEL_score,fathmm_MKL_coding_score,conservationScoreGnomad,conservationScoreOELof,Polyphen2_HDIV_score,Polyphen2_HVAR_score,SIFT_score,zyg,FATHMM_score,M_CAP_score,MutationAssessor_score,ESP6500_AA_AF,ESP6500_EA_AF,hom,hgmd_rs,spliceAImax,nc_ClinVar_Exp,nc_HGMD_Exp,nc_isPLP,nc_isBLB,c_isPLP,c_isBLB,nc_CLNREVSTAT,c_CLNREVSTAT,nc_RANKSCORE,c_RANKSCORE,CLASS,phrank,isB/LB,isP/LP,cons_transcript_ablation,cons_splice_acceptor_variant,cons_splice_donor_variant,cons_stop_gained,cons_frameshift_variant,cons_stop_lost,cons_start_lost,cons_transcript_amplification,cons_inframe_insertion,cons_inframe_deletion,cons_missense_variant,cons_protein_altering_variant,cons_splice_region_variant,cons_splice_donor_5th_base_variant,cons_splice_donor_region_variant,c_ClinVar_Exp_Del_to_Missense,c_ClinVar_Exp_Different_pChange,c_ClinVar_Exp_Same_pChange,c_HGMD_Exp_Del_to_Missense,c_HGMD_Exp_Different_pChange,c_HGMD_Exp_Same_pChange,c_HGMD_Exp_Stop_Loss,c_HGMD_Exp_Start_Loss,IMPACT.from.Tier,TierAD,TierAR,TierAR.adj,No.Var.HM,No.Var.H,No.Var.M,No.Var.L,AD.matched,AR.matched,recessive,dominant,simple_repeat"
+    
+    feature_names = 'diffuse_Phrank_STRING,hgmdSymptomScore,omimSymMatchFlag,hgmdSymMatchFlag,clinVarSymMatchFlag,omimGeneFound,omimVarFound,hgmdGeneFound,hgmdVarFound,clinVarVarFound,clinVarGeneFound,clinvarNumP,clinvarNumLP,clinvarNumLB,clinvarNumB,dgvVarFound,decipherVarFound,curationScoreHGMD,curationScoreOMIM,curationScoreClinVar,conservationScoreDGV,omimSymptomSimScore,hgmdSymptomSimScore,GERPpp_RS,gnomadAF,gnomadAFg,LRT_score,LRT_Omega,phyloP100way_vertebrate,gnomadGeneZscore,gnomadGenePLI,gnomadGeneOELof,gnomadGeneOELofUpper,IMPACT,CADD_phred,CADD_PHRED,DANN_score,REVEL_score,fathmm_MKL_coding_score,conservationScoreGnomad,conservationScoreOELof,Polyphen2_HDIV_score,Polyphen2_HVAR_score,SIFT_score,zyg,FATHMM_score,M_CAP_score,MutationAssessor_score,ESP6500_AA_AF,ESP6500_EA_AF,hom,hgmd_rs,spliceAImax,nc_ClinVar_Exp,nc_HGMD_Exp,nc_isPLP,nc_isBLB,c_isPLP,c_isBLB,nc_CLNREVSTAT,c_CLNREVSTAT,nc_RANKSCORE,c_RANKSCORE,CLASS,phrank,isB/LB,isP/LP,cons_transcript_ablation,cons_splice_acceptor_variant,cons_splice_donor_variant,cons_stop_gained,cons_frameshift_variant,cons_stop_lost,cons_start_lost,cons_transcript_amplification,cons_inframe_insertion,cons_inframe_deletion,cons_missense_variant,cons_protein_altering_variant,cons_splice_region_variant,cons_splice_donor_5th_base_variant,cons_splice_donor_region_variant,c_ClinVar_Exp_Del_to_Missense,c_ClinVar_Exp_Different_pChange,c_ClinVar_Exp_Same_pChange,c_HGMD_Exp_Del_to_Missense,c_HGMD_Exp_Different_pChange,c_HGMD_Exp_Same_pChange,c_HGMD_Exp_Stop_Loss,c_HGMD_Exp_Start_Loss,IMPACT.from.Tier,TierAD,TierAR,TierAR.adj,No.Var.HM,No.Var.H,No.Var.M,No.Var.L,AD.matched,AR.matched,recessive,dominant,simple_repeat'
     feature_names = feature_names.split(",")
     nFeatures = len(feature_names)
     bivar_feature_mats = []
 
-    gene = param["gene"]
-    varIDs, labeling = param["varIDs"], param["labeling"]
+    gene = param['gene']
+    varIDs, labeling = param['varIDs'], param['labeling']
 
-    feature_df, out_folder = param["feature_df"], param["out_folder"]
+    
+    feature_df, out_folder = param['feature_df'], param['out_folder']
 
-    seen_pairs = set()
-
+    seen_pairs = set() 
+    
     allVars = feature_df.index.tolist()
     varIDs = [v for v in varIDs if v in allVars]
 
@@ -115,8 +116,8 @@ def process_gene(param):
         return
 
     if len(varIDs) > 6:
-        defaultPred = param["default_pred"].copy()
-        defaultPred = defaultPred.loc[varIDs, :].sort_values(["predict", "IMPACT.from.Tier"], ascending=[False, False], kind="stable") 
+        defaultPred = param['default_pred'].copy()
+        defaultPred = defaultPred.loc[varIDs,:].sort_values(["predict", "IMPACT.from.Tier"], ascending=[False, False], kind="stable") 
         varIDs = defaultPred.index.tolist()[:6]
 
     gene_feats = feature_df.loc[varIDs, feature_names].copy()
@@ -126,66 +127,60 @@ def process_gene(param):
 
     def generate_feature_vector(i, j):
         fmat = np.zeros((2, nFeatures * 2 + 1))
-        dist = np.absolute(int(varIDs[i].split("-")[1]) - int(varIDs[j].split("-")[1]))
-
+        dist = np.absolute(int(varIDs[i].split("-")[1])-int(varIDs[j].split("-")[1]))
+        
         fmat[0] = np.append(np.append(gene_feats[i], gene_feats[j]), [dist])
         fmat[1] = np.append(np.append(gene_feats[j], gene_feats[i]), [dist])
 
-        f1_features = [f"{f}_1" for f in feature_names]
-        f2_features = [f"{f}_2" for f in feature_names]
-
-        return pd.DataFrame(
-            data=fmat,
-            columns=f1_features + f2_features + ["var_dist"],
-            index=[f"{varIDs[i]}_{varIDs[j]}", f"{varIDs[j]}_{varIDs[i]}"],
-        )
+        f1_features = [f'{f}_1' for f in feature_names]
+        f2_features = [f'{f}_2' for f in feature_names]
+        
+        return pd.DataFrame(data=fmat, columns=f1_features + f2_features + ['var_dist'],
+                            index=[f'{varIDs[i]}_{varIDs[j]}', f'{varIDs[j]}_{varIDs[i]}'])
+        
 
     for i in range(len(varIDs)):
-        varii_feature_matrix = generate_feature_vector(i, i)
+        varii_feature_matrix = generate_feature_vector(i,i)            
         var1 = varIDs[i]
+        
+        if f'{var1}_{var1}' not in seen_pairs:               
+            if feature_df.loc[var1, 'zyg'] == 2:
 
-        if f"{var1}_{var1}" not in seen_pairs:
-            if feature_df.loc[var1, "zyg"] == 2:
-
-                if labeling:
-                    if feature_df.loc[var1, "is_strong"] == 1:
+                if labeling:                        
+                    if feature_df.loc[var1, 'is_strong'] == 1:
                         is_causal_wo_OMIM = 1
                     else:
                         is_causal_wo_OMIM = 0
-                    varii_feature_matrix["is_causal"] = is_causal_wo_OMIM
-
+                    varii_feature_matrix['is_causal'] = is_causal_wo_OMIM
+                
                 bivar_feature_mats.append(varii_feature_matrix)
-                seen_pairs.add(f"{var1}_{var1}")
-
+                seen_pairs.add(f'{var1}_{var1}')
+        
         if i < len(varIDs) - 1:
-            for j in range(i + 1, len(varIDs)):
+            for j in range(i+1, len(varIDs)):
                 var2 = varIDs[j]
-                if (
-                    (f"{var1}_{var2}" not in seen_pairs)
-                    and (f"{var2}_{var1}" not in seen_pairs)
-                    and (var1 != var2)
-                ):
+                if (f'{var1}_{var2}' not in seen_pairs) and (f'{var2}_{var1}' not in seen_pairs) and (var1 != var2):
                     varij_feature_matrix = generate_feature_vector(i, j)
-
+                    
                     if labeling:
                         is_causal_wo_OMIM = 0
 
-                        if (feature_df.loc[[var1, var2], "is_strong"] == 1).all():
-                            if (feature_df.loc[[var1, var2], "zyg"] == 1).all():
-                                is_causal_wo_OMIM = 1
+                        if (feature_df.loc[[var1, var2], 'is_strong'] == 1).all():
+                            if (feature_df.loc[[var1, var2], 'zyg'] == 1).all():
+                                is_causal_wo_OMIM = 1    
 
-                        varij_feature_matrix["is_causal"] = is_causal_wo_OMIM
+                        varij_feature_matrix['is_causal'] = is_causal_wo_OMIM
 
                     bivar_feature_mats.append(varij_feature_matrix)
 
-                    seen_pairs.add(f"{var1}_{var2}")
-                    seen_pairs.add(f"{var2}_{var1}")
+                    seen_pairs.add(f'{var1}_{var2}')
+                    seen_pairs.add(f'{var2}_{var1}')
                 else:
                     pass
 
-    if len(bivar_feature_mats) > 0:
+    if len(bivar_feature_mats) > 0:          
         bivar_feature_mats = pd.concat(bivar_feature_mats, axis=0)
         bivar_feature_mats = bivar_feature_mats.drop_duplicates()
-        bivar_feature_mats.to_csv(f"{out_folder}/{gene}.csv")
-
+        bivar_feature_mats.to_csv(f"{out_folder}/{gene}.csv")    
+    
     return

--- a/bin/extraModel/generate_bivar_data.py
+++ b/bin/extraModel/generate_bivar_data.py
@@ -1,19 +1,16 @@
-import pandas as pd
 import os
+import itertools
+import pandas as pd
 import numpy as np
 from glob import glob
 from tqdm import tqdm, trange
 import logging
-from multiprocessing import Pool
 from os.path import exists
 import shutil
 
-
-def process_sample(data_folder, sample_id, default_pred, labeling=False, n_thread=10):
-
-    # recessive_folder = f'{data_folder}/recessive_matrix'
-    # if not os.path.exists(recessive_folder):
-    #     os.mkdir(recessive_folder)
+def process_sample(data_folder, sample_id, default_pred, labeling=False):
+    if labeling:
+        raise 'The below code was not tested with real data with labeling=True'
 
     recessive_folder = f"{data_folder}/recessive_matrix/"
     if not os.path.exists(recessive_folder):
@@ -23,7 +20,7 @@ def process_sample(data_folder, sample_id, default_pred, labeling=False, n_threa
     if not os.path.exists(tmp_folder):
         os.mkdir(tmp_folder)
 
-    ## read feature matrix for single var
+    # read feature matrix for single var
     feature_fn = f"{sample_id}.csv"
     # feature_df = []
     # for feature_fn in feature_fns:
@@ -35,9 +32,8 @@ def process_sample(data_folder, sample_id, default_pred, labeling=False, n_threa
     # feature_df = pd.concat(feature_df)
     feature_df = feature_df.loc[~feature_df.index.duplicated(keep="first")]
 
-    ## Group variants by Ens IDs
+    # Group variants by Ens IDs
     expanded_fn = f"final_matrix_expanded/{sample_id}.expanded.csv.gz"
-    gene_dict = {}
     # for expanded_fn in expanded_fns:
     if "csv" in expanded_fn:
         df = pd.read_csv(expanded_fn, sep=",", index_col=0, compression="infer")
@@ -47,140 +43,90 @@ def process_sample(data_folder, sample_id, default_pred, labeling=False, n_threa
     if df.shape[0] > 100000:
         df = df.loc[df["IMPACT.from.Tier"] > 1]
 
-    for varId, gene in zip(df.index.tolist(), df.geneEnsId.tolist()):
-        if gene.startswith("ENSG"):
-            if gene not in gene_dict:
-                gene_dict[gene] = {varId}
-            else:
-                gene_dict[gene].add(varId)
+    varId_geneEnsId_df = df[['geneEnsId']]
+    varId_geneEnsId_df.index.name = 'varId'
 
-    ## create parameters and run bivar feature generation in parallel
-    params = [
-        {
-            "feature_df": feature_df,
-            "default_pred": default_pred,
-            "labeling": labeling,
-            "out_folder": f"{tmp_folder}",
-            "gene": gene,
-            "varIDs": list(gene_dict[gene]),
-        }
-        for gene in gene_dict
-    ]
-    print(
-        f"Now starting to generate recessive feature matrix for {len(gene_dict)} genes, {feature_df.shape[0]} variants using {n_thread} threads."
+    geneEnsId_varId_df = varId_geneEnsId_df[varId_geneEnsId_df.geneEnsId.str.startswith("ENSG")] \
+        .reset_index() \
+        .sort_values(['geneEnsId', 'varId']) \
+        .drop_duplicates()
+
+    # Generate variant pairs for each gene
+    gene_var_pairs = []
+    for geneEnsId, grouped_df in geneEnsId_varId_df.groupby('geneEnsId'):
+        # Choose upto 6 the most meaningful variants.
+        if grouped_df.shape[0] > 6:
+            grouped_df = grouped_df \
+                .join(default_pred, on='varId') \
+                .sort_values(["predict", "IMPACT.from.Tier"], ascending=[False, False], kind="stable") \
+                .head(6)
+
+        gene_var_pairs += [
+            {"geneEnsId": geneEnsId, "varId1": pair[0][1].varId, "varId2": pair[1][1].varId}
+            for pair in itertools.product(grouped_df.iterrows(), grouped_df.iterrows())
+        ]
+
+    # Remove all the duplicated variant pairs.
+    gene_var_pairs_df = pd.DataFrame(gene_var_pairs)
+    gene_var_pairs_df = gene_var_pairs_df.drop_duplicates(['varId1', 'varId2'])
+
+    # Use only subset columns of features
+    subset_feature_names = "diffuse_Phrank_STRING,hgmdSymptomScore,omimSymMatchFlag,hgmdSymMatchFlag,clinVarSymMatchFlag,omimGeneFound,omimVarFound,hgmdGeneFound,hgmdVarFound,clinVarVarFound,clinVarGeneFound,clinvarNumP,clinvarNumLP,clinvarNumLB,clinvarNumB,dgvVarFound,decipherVarFound,curationScoreHGMD,curationScoreOMIM,curationScoreClinVar,conservationScoreDGV,omimSymptomSimScore,hgmdSymptomSimScore,GERPpp_RS,gnomadAF,gnomadAFg,LRT_score,LRT_Omega,phyloP100way_vertebrate,gnomadGeneZscore,gnomadGenePLI,gnomadGeneOELof,gnomadGeneOELofUpper,IMPACT,CADD_phred,CADD_PHRED,DANN_score,REVEL_score,fathmm_MKL_coding_score,conservationScoreGnomad,conservationScoreOELof,Polyphen2_HDIV_score,Polyphen2_HVAR_score,SIFT_score,zyg,FATHMM_score,M_CAP_score,MutationAssessor_score,ESP6500_AA_AF,ESP6500_EA_AF,hom,hgmd_rs,spliceAImax,nc_ClinVar_Exp,nc_HGMD_Exp,nc_isPLP,nc_isBLB,c_isPLP,c_isBLB,nc_CLNREVSTAT,c_CLNREVSTAT,nc_RANKSCORE,c_RANKSCORE,CLASS,phrank,isB/LB,isP/LP,cons_transcript_ablation,cons_splice_acceptor_variant,cons_splice_donor_variant,cons_stop_gained,cons_frameshift_variant,cons_stop_lost,cons_start_lost,cons_transcript_amplification,cons_inframe_insertion,cons_inframe_deletion,cons_missense_variant,cons_protein_altering_variant,cons_splice_region_variant,cons_splice_donor_5th_base_variant,cons_splice_donor_region_variant,c_ClinVar_Exp_Del_to_Missense,c_ClinVar_Exp_Different_pChange,c_ClinVar_Exp_Same_pChange,c_HGMD_Exp_Del_to_Missense,c_HGMD_Exp_Different_pChange,c_HGMD_Exp_Same_pChange,c_HGMD_Exp_Stop_Loss,c_HGMD_Exp_Start_Loss,IMPACT.from.Tier,TierAD,TierAR,TierAR.adj,No.Var.HM,No.Var.H,No.Var.M,No.Var.L,AD.matched,AR.matched,recessive,dominant,simple_repeat".split(',')
+    if labeling:
+        subset_feature_names.append('is_strong')
+    subset_feature_df = feature_df[subset_feature_names]
+
+    # Join feature matrix for each variant pairs.
+    recessive_feature_df = gene_var_pairs_df.join(
+        subset_feature_df.add_suffix('_1'),
+        on="varId1"
+    ).join(
+        subset_feature_df.add_suffix('_2'),
+        on="varId2"
     )
-    p = Pool(processes=n_thread)
 
-    with tqdm(total=len(params)) as pbar:
-        for result in p.imap_unordered(process_gene, params):
-            pbar.update()
-    p.close()
-    p.join()
-    print("Recessive features for each gene finished, now putting together...")
+    # Remove unnecessary var_i == var_j cases because of zygosity
+    recessive_feature_df = recessive_feature_df[
+        ~((recessive_feature_df.varId1 == recessive_feature_df.varId2) &
+          (recessive_feature_df.zyg_1 != 2))
+    ]
 
-    bivar_feature_mats = []
-    fns = glob(tmp_folder + "/*.csv")
-    for fn in tqdm(fns, total=len(fns)):
-        df = pd.read_csv(fn, index_col=0)
-        bivar_feature_mats.append(df)
-    if bivar_feature_mats:
-        bivar_feature_mats = pd.concat(bivar_feature_mats)
-        bivar_feature_mats.to_csv(f"{recessive_folder}/{sample_id}.csv")
-        print("Recessive features saved, now removing tmp files...")
-        print("Recessive features generation finished...")
-    else:
-        print("No recessive variant pair found. End and remove temp files")
+    # Calculate variant distance
+    recessive_feature_df['var_dist'] = (
+        recessive_feature_df.varId1.str.split('-').apply(lambda x: x[1]).astype(float)
+        - recessive_feature_df.varId2.str.split('-').apply(lambda x: x[1]).astype(float)
+    ).abs()
 
-    shutil.rmtree(f"{tmp_folder}")
+    # Calculate label
+    if labeling:
+        recessive_feature_df['is_causal'] = (
+            (recessive_feature_df.varId1 == recessive_feature_df.varId2) &
+            (recessive_feature_df.zyg_1 == 2) &
+            (recessive_feature_df.is_strong_1 == 1)
+        ) | (
+            (recessive_feature_df.varId1 != recessive_feature_df.varId2) &
+            (recessive_feature_df.zyg_1 == 1) &
+            (recessive_feature_df.zyg_2 == 1) &
+            (recessive_feature_df.is_strong_1 == 1) &
+            (recessive_feature_df.is_strong_2 == 1)
+        )
 
+    # Create pair id as the legacy did
+    recessive_feature_df = recessive_feature_df.set_index(recessive_feature_df.varId1 + '_' + recessive_feature_df.varId2)
 
-def process_gene(param):
-    
-    feature_names = 'diffuse_Phrank_STRING,hgmdSymptomScore,omimSymMatchFlag,hgmdSymMatchFlag,clinVarSymMatchFlag,omimGeneFound,omimVarFound,hgmdGeneFound,hgmdVarFound,clinVarVarFound,clinVarGeneFound,clinvarNumP,clinvarNumLP,clinvarNumLB,clinvarNumB,dgvVarFound,decipherVarFound,curationScoreHGMD,curationScoreOMIM,curationScoreClinVar,conservationScoreDGV,omimSymptomSimScore,hgmdSymptomSimScore,GERPpp_RS,gnomadAF,gnomadAFg,LRT_score,LRT_Omega,phyloP100way_vertebrate,gnomadGeneZscore,gnomadGenePLI,gnomadGeneOELof,gnomadGeneOELofUpper,IMPACT,CADD_phred,CADD_PHRED,DANN_score,REVEL_score,fathmm_MKL_coding_score,conservationScoreGnomad,conservationScoreOELof,Polyphen2_HDIV_score,Polyphen2_HVAR_score,SIFT_score,zyg,FATHMM_score,M_CAP_score,MutationAssessor_score,ESP6500_AA_AF,ESP6500_EA_AF,hom,hgmd_rs,spliceAImax,nc_ClinVar_Exp,nc_HGMD_Exp,nc_isPLP,nc_isBLB,c_isPLP,c_isBLB,nc_CLNREVSTAT,c_CLNREVSTAT,nc_RANKSCORE,c_RANKSCORE,CLASS,phrank,isB/LB,isP/LP,cons_transcript_ablation,cons_splice_acceptor_variant,cons_splice_donor_variant,cons_stop_gained,cons_frameshift_variant,cons_stop_lost,cons_start_lost,cons_transcript_amplification,cons_inframe_insertion,cons_inframe_deletion,cons_missense_variant,cons_protein_altering_variant,cons_splice_region_variant,cons_splice_donor_5th_base_variant,cons_splice_donor_region_variant,c_ClinVar_Exp_Del_to_Missense,c_ClinVar_Exp_Different_pChange,c_ClinVar_Exp_Same_pChange,c_HGMD_Exp_Del_to_Missense,c_HGMD_Exp_Different_pChange,c_HGMD_Exp_Same_pChange,c_HGMD_Exp_Stop_Loss,c_HGMD_Exp_Start_Loss,IMPACT.from.Tier,TierAD,TierAR,TierAR.adj,No.Var.HM,No.Var.H,No.Var.M,No.Var.L,AD.matched,AR.matched,recessive,dominant,simple_repeat'
-    feature_names = feature_names.split(",")
-    nFeatures = len(feature_names)
-    bivar_feature_mats = []
+    # Drop the intermediate columns
+    recessive_feature_df = recessive_feature_df.drop(
+        columns=['geneEnsId', 'varId1', 'varId2']
+    )
+    if labeling:
+        recessive_feature_df = recessive_feature_df.drop(
+            columns=['is_strong_1', 'is_strong_2']
+        )
 
-    gene = param['gene']
-    varIDs, labeling = param['varIDs'], param['labeling']
+    # Cast all the values to float as the legacy did
+    recessive_feature_df = recessive_feature_df.astype(float)
 
-    
-    feature_df, out_folder = param['feature_df'], param['out_folder']
+    # Sort before saving
+    recessive_feature_df = recessive_feature_df.sort_index()
 
-    seen_pairs = set() 
-    
-    allVars = feature_df.index.tolist()
-    varIDs = sorted([v for v in varIDs if v in allVars])
-
-    if len(varIDs) == 0:
-        return
-
-    if len(varIDs) > 6:
-        defaultPred = param['default_pred'].copy()
-        defaultPred = defaultPred.loc[varIDs,:].sort_values(["predict", "IMPACT.from.Tier"], ascending=[False, False], kind="stable") 
-        varIDs = defaultPred.index.tolist()[:6]
-
-    gene_feats = feature_df.loc[varIDs, feature_names].copy()
-    gene_feats = gene_feats.values
-    assert gene_feats.shape[0] == len(varIDs)
-    # print(gene_feats, varIDs)
-
-    def generate_feature_vector(i, j):
-        fmat = np.zeros((2, nFeatures * 2 + 1))
-        dist = np.absolute(int(varIDs[i].split("-")[1])-int(varIDs[j].split("-")[1]))
-        
-        fmat[0] = np.append(np.append(gene_feats[i], gene_feats[j]), [dist])
-        fmat[1] = np.append(np.append(gene_feats[j], gene_feats[i]), [dist])
-
-        f1_features = [f'{f}_1' for f in feature_names]
-        f2_features = [f'{f}_2' for f in feature_names]
-        
-        return pd.DataFrame(data=fmat, columns=f1_features + f2_features + ['var_dist'],
-                            index=[f'{varIDs[i]}_{varIDs[j]}', f'{varIDs[j]}_{varIDs[i]}'])
-        
-
-    for i in range(len(varIDs)):
-        varii_feature_matrix = generate_feature_vector(i,i)            
-        var1 = varIDs[i]
-        
-        if f'{var1}_{var1}' not in seen_pairs:               
-            if feature_df.loc[var1, 'zyg'] == 2:
-
-                if labeling:                        
-                    if feature_df.loc[var1, 'is_strong'] == 1:
-                        is_causal_wo_OMIM = 1
-                    else:
-                        is_causal_wo_OMIM = 0
-                    varii_feature_matrix['is_causal'] = is_causal_wo_OMIM
-                
-                bivar_feature_mats.append(varii_feature_matrix)
-                seen_pairs.add(f'{var1}_{var1}')
-        
-        if i < len(varIDs) - 1:
-            for j in range(i+1, len(varIDs)):
-                var2 = varIDs[j]
-                if (f'{var1}_{var2}' not in seen_pairs) and (f'{var2}_{var1}' not in seen_pairs) and (var1 != var2):
-                    varij_feature_matrix = generate_feature_vector(i, j)
-                    
-                    if labeling:
-                        is_causal_wo_OMIM = 0
-
-                        if (feature_df.loc[[var1, var2], 'is_strong'] == 1).all():
-                            if (feature_df.loc[[var1, var2], 'zyg'] == 1).all():
-                                is_causal_wo_OMIM = 1    
-
-                        varij_feature_matrix['is_causal'] = is_causal_wo_OMIM
-
-                    bivar_feature_mats.append(varij_feature_matrix)
-
-                    seen_pairs.add(f'{var1}_{var2}')
-                    seen_pairs.add(f'{var2}_{var1}')
-                else:
-                    pass
-
-    if len(bivar_feature_mats) > 0:          
-        bivar_feature_mats = pd.concat(bivar_feature_mats, axis=0)
-        bivar_feature_mats = bivar_feature_mats.drop_duplicates()
-        bivar_feature_mats.to_csv(f"{out_folder}/{gene}.csv")    
-    
-    return
+    recessive_feature_df.to_csv(f"{recessive_folder}/{sample_id}.csv")

--- a/bin/extraModel/generate_bivar_data.py
+++ b/bin/extraModel/generate_bivar_data.py
@@ -1,16 +1,19 @@
-import os
-import itertools
 import pandas as pd
+import os
 import numpy as np
 from glob import glob
 from tqdm import tqdm, trange
 import logging
+from multiprocessing import Pool
 from os.path import exists
 import shutil
 
-def process_sample(data_folder, sample_id, default_pred, labeling=False):
-    if labeling:
-        raise 'The below code was not tested with real data with labeling=True'
+
+def process_sample(data_folder, sample_id, default_pred, labeling=False, n_thread=10):
+
+    # recessive_folder = f'{data_folder}/recessive_matrix'
+    # if not os.path.exists(recessive_folder):
+    #     os.mkdir(recessive_folder)
 
     recessive_folder = f"{data_folder}/recessive_matrix/"
     if not os.path.exists(recessive_folder):
@@ -20,7 +23,7 @@ def process_sample(data_folder, sample_id, default_pred, labeling=False):
     if not os.path.exists(tmp_folder):
         os.mkdir(tmp_folder)
 
-    # read feature matrix for single var
+    ## read feature matrix for single var
     feature_fn = f"{sample_id}.csv"
     # feature_df = []
     # for feature_fn in feature_fns:
@@ -32,8 +35,9 @@ def process_sample(data_folder, sample_id, default_pred, labeling=False):
     # feature_df = pd.concat(feature_df)
     feature_df = feature_df.loc[~feature_df.index.duplicated(keep="first")]
 
-    # Group variants by Ens IDs
+    ## Group variants by Ens IDs
     expanded_fn = f"final_matrix_expanded/{sample_id}.expanded.csv.gz"
+    gene_dict = {}
     # for expanded_fn in expanded_fns:
     if "csv" in expanded_fn:
         df = pd.read_csv(expanded_fn, sep=",", index_col=0, compression="infer")
@@ -43,90 +47,145 @@ def process_sample(data_folder, sample_id, default_pred, labeling=False):
     if df.shape[0] > 100000:
         df = df.loc[df["IMPACT.from.Tier"] > 1]
 
-    varId_geneEnsId_df = df[['geneEnsId']]
-    varId_geneEnsId_df.index.name = 'varId'
+    for varId, gene in zip(df.index.tolist(), df.geneEnsId.tolist()):
+        if gene.startswith("ENSG"):
+            if gene not in gene_dict:
+                gene_dict[gene] = {varId}
+            else:
+                gene_dict[gene].add(varId)
 
-    geneEnsId_varId_df = varId_geneEnsId_df[varId_geneEnsId_df.geneEnsId.str.startswith("ENSG")] \
-        .reset_index() \
-        .sort_values(['geneEnsId', 'varId']) \
-        .drop_duplicates()
-
-    # Generate variant pairs for each gene
-    gene_var_pairs = []
-    for geneEnsId, grouped_df in geneEnsId_varId_df.groupby('geneEnsId'):
-        # Choose upto 6 the most meaningful variants.
-        if grouped_df.shape[0] > 6:
-            grouped_df = grouped_df \
-                .join(default_pred, on='varId') \
-                .sort_values(["predict", "IMPACT.from.Tier"], ascending=[False, False], kind="stable") \
-                .head(6)
-
-        gene_var_pairs += [
-            {"geneEnsId": geneEnsId, "varId1": pair[0][1].varId, "varId2": pair[1][1].varId}
-            for pair in itertools.product(grouped_df.iterrows(), grouped_df.iterrows())
-        ]
-
-    # Remove all the duplicated variant pairs.
-    gene_var_pairs_df = pd.DataFrame(gene_var_pairs)
-    gene_var_pairs_df = gene_var_pairs_df.drop_duplicates(['varId1', 'varId2'])
-
-    # Use only subset columns of features
-    subset_feature_names = "diffuse_Phrank_STRING,hgmdSymptomScore,omimSymMatchFlag,hgmdSymMatchFlag,clinVarSymMatchFlag,omimGeneFound,omimVarFound,hgmdGeneFound,hgmdVarFound,clinVarVarFound,clinVarGeneFound,clinvarNumP,clinvarNumLP,clinvarNumLB,clinvarNumB,dgvVarFound,decipherVarFound,curationScoreHGMD,curationScoreOMIM,curationScoreClinVar,conservationScoreDGV,omimSymptomSimScore,hgmdSymptomSimScore,GERPpp_RS,gnomadAF,gnomadAFg,LRT_score,LRT_Omega,phyloP100way_vertebrate,gnomadGeneZscore,gnomadGenePLI,gnomadGeneOELof,gnomadGeneOELofUpper,IMPACT,CADD_phred,CADD_PHRED,DANN_score,REVEL_score,fathmm_MKL_coding_score,conservationScoreGnomad,conservationScoreOELof,Polyphen2_HDIV_score,Polyphen2_HVAR_score,SIFT_score,zyg,FATHMM_score,M_CAP_score,MutationAssessor_score,ESP6500_AA_AF,ESP6500_EA_AF,hom,hgmd_rs,spliceAImax,nc_ClinVar_Exp,nc_HGMD_Exp,nc_isPLP,nc_isBLB,c_isPLP,c_isBLB,nc_CLNREVSTAT,c_CLNREVSTAT,nc_RANKSCORE,c_RANKSCORE,CLASS,phrank,isB/LB,isP/LP,cons_transcript_ablation,cons_splice_acceptor_variant,cons_splice_donor_variant,cons_stop_gained,cons_frameshift_variant,cons_stop_lost,cons_start_lost,cons_transcript_amplification,cons_inframe_insertion,cons_inframe_deletion,cons_missense_variant,cons_protein_altering_variant,cons_splice_region_variant,cons_splice_donor_5th_base_variant,cons_splice_donor_region_variant,c_ClinVar_Exp_Del_to_Missense,c_ClinVar_Exp_Different_pChange,c_ClinVar_Exp_Same_pChange,c_HGMD_Exp_Del_to_Missense,c_HGMD_Exp_Different_pChange,c_HGMD_Exp_Same_pChange,c_HGMD_Exp_Stop_Loss,c_HGMD_Exp_Start_Loss,IMPACT.from.Tier,TierAD,TierAR,TierAR.adj,No.Var.HM,No.Var.H,No.Var.M,No.Var.L,AD.matched,AR.matched,recessive,dominant,simple_repeat".split(',')
-    if labeling:
-        subset_feature_names.append('is_strong')
-    subset_feature_df = feature_df[subset_feature_names]
-
-    # Join feature matrix for each variant pairs.
-    recessive_feature_df = gene_var_pairs_df.join(
-        subset_feature_df.add_suffix('_1'),
-        on="varId1"
-    ).join(
-        subset_feature_df.add_suffix('_2'),
-        on="varId2"
-    )
-
-    # Remove unnecessary var_i == var_j cases because of zygosity
-    recessive_feature_df = recessive_feature_df[
-        ~((recessive_feature_df.varId1 == recessive_feature_df.varId2) &
-          (recessive_feature_df.zyg_1 != 2))
+    ## create parameters and run bivar feature generation in parallel
+    params = [
+        {
+            "feature_df": feature_df,
+            "default_pred": default_pred,
+            "labeling": labeling,
+            "out_folder": f"{tmp_folder}",
+            "gene": gene,
+            "varIDs": list(gene_dict[gene]),
+        }
+        for gene in gene_dict
     ]
-
-    # Calculate variant distance
-    recessive_feature_df['var_dist'] = (
-        recessive_feature_df.varId1.str.split('-').apply(lambda x: x[1]).astype(float)
-        - recessive_feature_df.varId2.str.split('-').apply(lambda x: x[1]).astype(float)
-    ).abs()
-
-    # Calculate label
-    if labeling:
-        recessive_feature_df['is_causal'] = (
-            (recessive_feature_df.varId1 == recessive_feature_df.varId2) &
-            (recessive_feature_df.zyg_1 == 2) &
-            (recessive_feature_df.is_strong_1 == 1)
-        ) | (
-            (recessive_feature_df.varId1 != recessive_feature_df.varId2) &
-            (recessive_feature_df.zyg_1 == 1) &
-            (recessive_feature_df.zyg_2 == 1) &
-            (recessive_feature_df.is_strong_1 == 1) &
-            (recessive_feature_df.is_strong_2 == 1)
-        )
-
-    # Create pair id as the legacy did
-    recessive_feature_df = recessive_feature_df.set_index(recessive_feature_df.varId1 + '_' + recessive_feature_df.varId2)
-
-    # Drop the intermediate columns
-    recessive_feature_df = recessive_feature_df.drop(
-        columns=['geneEnsId', 'varId1', 'varId2']
+    print(
+        f"Now starting to generate recessive feature matrix for {len(gene_dict)} genes, {feature_df.shape[0]} variants using {n_thread} threads."
     )
-    if labeling:
-        recessive_feature_df = recessive_feature_df.drop(
-            columns=['is_strong_1', 'is_strong_2']
+    p = Pool(processes=n_thread)
+
+    with tqdm(total=len(params)) as pbar:
+        for result in p.imap_unordered(process_gene, params):
+            pbar.update()
+    p.close()
+    p.join()
+    print("Recessive features for each gene finished, now putting together...")
+
+    bivar_feature_mats = []
+    fns = glob(tmp_folder + "/*.csv")
+    for fn in tqdm(fns, total=len(fns)):
+        df = pd.read_csv(fn, index_col=0)
+        bivar_feature_mats.append(df)
+    if bivar_feature_mats:
+        bivar_feature_mats = pd.concat(bivar_feature_mats)
+        bivar_feature_mats.to_csv(f"{recessive_folder}/{sample_id}.csv")
+        print("Recessive features saved, now removing tmp files...")
+        print("Recessive features generation finished...")
+    else:
+        print("No recessive variant pair found. End and remove temp files")
+
+    shutil.rmtree(f"{tmp_folder}")
+
+
+def process_gene(param):
+
+    feature_names = "diffuse_Phrank_STRING,hgmdSymptomScore,omimSymMatchFlag,hgmdSymMatchFlag,clinVarSymMatchFlag,omimGeneFound,omimVarFound,hgmdGeneFound,hgmdVarFound,clinVarVarFound,clinVarGeneFound,clinvarNumP,clinvarNumLP,clinvarNumLB,clinvarNumB,dgvVarFound,decipherVarFound,curationScoreHGMD,curationScoreOMIM,curationScoreClinVar,conservationScoreDGV,omimSymptomSimScore,hgmdSymptomSimScore,GERPpp_RS,gnomadAF,gnomadAFg,LRT_score,LRT_Omega,phyloP100way_vertebrate,gnomadGeneZscore,gnomadGenePLI,gnomadGeneOELof,gnomadGeneOELofUpper,IMPACT,CADD_phred,CADD_PHRED,DANN_score,REVEL_score,fathmm_MKL_coding_score,conservationScoreGnomad,conservationScoreOELof,Polyphen2_HDIV_score,Polyphen2_HVAR_score,SIFT_score,zyg,FATHMM_score,M_CAP_score,MutationAssessor_score,ESP6500_AA_AF,ESP6500_EA_AF,hom,hgmd_rs,spliceAImax,nc_ClinVar_Exp,nc_HGMD_Exp,nc_isPLP,nc_isBLB,c_isPLP,c_isBLB,nc_CLNREVSTAT,c_CLNREVSTAT,nc_RANKSCORE,c_RANKSCORE,CLASS,phrank,isB/LB,isP/LP,cons_transcript_ablation,cons_splice_acceptor_variant,cons_splice_donor_variant,cons_stop_gained,cons_frameshift_variant,cons_stop_lost,cons_start_lost,cons_transcript_amplification,cons_inframe_insertion,cons_inframe_deletion,cons_missense_variant,cons_protein_altering_variant,cons_splice_region_variant,cons_splice_donor_5th_base_variant,cons_splice_donor_region_variant,c_ClinVar_Exp_Del_to_Missense,c_ClinVar_Exp_Different_pChange,c_ClinVar_Exp_Same_pChange,c_HGMD_Exp_Del_to_Missense,c_HGMD_Exp_Different_pChange,c_HGMD_Exp_Same_pChange,c_HGMD_Exp_Stop_Loss,c_HGMD_Exp_Start_Loss,IMPACT.from.Tier,TierAD,TierAR,TierAR.adj,No.Var.HM,No.Var.H,No.Var.M,No.Var.L,AD.matched,AR.matched,recessive,dominant,simple_repeat"
+    feature_names = feature_names.split(",")
+    nFeatures = len(feature_names)
+    bivar_feature_mats = []
+
+    gene = param["gene"]
+    varIDs, labeling = param["varIDs"], param["labeling"]
+
+    feature_df, out_folder = param["feature_df"], param["out_folder"]
+
+    seen_pairs = set()
+
+    allVars = feature_df.index.tolist()
+    varIDs = [v for v in varIDs if v in allVars]
+
+    if len(varIDs) == 0:
+        return
+
+    if len(varIDs) > 6:
+        defaultPred = param["default_pred"].copy()
+        defaultPred = defaultPred.loc[varIDs, :].sort_values("predict", ascending=False)
+        varIDs = defaultPred.index.tolist()[:6]
+
+    gene_feats = feature_df.loc[varIDs, feature_names].copy()
+    gene_feats = gene_feats.values
+    assert gene_feats.shape[0] == len(varIDs)
+    # print(gene_feats, varIDs)
+
+    def generate_feature_vector(i, j):
+        fmat = np.zeros((2, nFeatures * 2 + 1))
+        dist = np.absolute(int(varIDs[i].split("-")[1]) - int(varIDs[j].split("-")[1]))
+
+        fmat[0] = np.append(np.append(gene_feats[i], gene_feats[j]), [dist])
+        fmat[1] = np.append(np.append(gene_feats[j], gene_feats[i]), [dist])
+
+        f1_features = [f"{f}_1" for f in feature_names]
+        f2_features = [f"{f}_2" for f in feature_names]
+
+        return pd.DataFrame(
+            data=fmat,
+            columns=f1_features + f2_features + ["var_dist"],
+            index=[f"{varIDs[i]}_{varIDs[j]}", f"{varIDs[j]}_{varIDs[i]}"],
         )
 
-    # Cast all the values to float as the legacy did
-    recessive_feature_df = recessive_feature_df.astype(float)
+    for i in range(len(varIDs)):
+        varii_feature_matrix = generate_feature_vector(i, i)
+        var1 = varIDs[i]
 
-    # Sort before saving
-    recessive_feature_df = recessive_feature_df.sort_index()
+        if f"{var1}_{var1}" not in seen_pairs:
+            if feature_df.loc[var1, "zyg"] == 2:
 
-    recessive_feature_df.to_csv(f"{recessive_folder}/{sample_id}.csv")
+                if labeling:
+                    if feature_df.loc[var1, "is_strong"] == 1:
+                        is_causal_wo_OMIM = 1
+                    else:
+                        is_causal_wo_OMIM = 0
+                    varii_feature_matrix["is_causal"] = is_causal_wo_OMIM
+
+                bivar_feature_mats.append(varii_feature_matrix)
+                seen_pairs.add(f"{var1}_{var1}")
+
+        if i < len(varIDs) - 1:
+            for j in range(i + 1, len(varIDs)):
+                var2 = varIDs[j]
+                if (
+                    (f"{var1}_{var2}" not in seen_pairs)
+                    and (f"{var2}_{var1}" not in seen_pairs)
+                    and (var1 != var2)
+                ):
+                    varij_feature_matrix = generate_feature_vector(i, j)
+
+                    if labeling:
+                        is_causal_wo_OMIM = 0
+
+                        if (feature_df.loc[[var1, var2], "is_strong"] == 1).all():
+                            if (feature_df.loc[[var1, var2], "zyg"] == 1).all():
+                                is_causal_wo_OMIM = 1
+
+                        varij_feature_matrix["is_causal"] = is_causal_wo_OMIM
+
+                    bivar_feature_mats.append(varij_feature_matrix)
+
+                    seen_pairs.add(f"{var1}_{var2}")
+                    seen_pairs.add(f"{var2}_{var1}")
+                else:
+                    pass
+
+    if len(bivar_feature_mats) > 0:
+        bivar_feature_mats = pd.concat(bivar_feature_mats, axis=0)
+        bivar_feature_mats = bivar_feature_mats.drop_duplicates()
+        bivar_feature_mats.to_csv(f"{out_folder}/{gene}.csv")
+
+    return

--- a/bin/extraModel/generate_bivar_data.py
+++ b/bin/extraModel/generate_bivar_data.py
@@ -116,7 +116,7 @@ def process_gene(param):
 
     if len(varIDs) > 6:
         defaultPred = param["default_pred"].copy()
-        defaultPred = defaultPred.loc[varIDs, :].sort_values("predict", ascending=False)
+        defaultPred = defaultPred.loc[varIDs, :].sort_values(["predict", "IMPACT.from.Tier"], ascending=[False, False], kind="stable") 
         varIDs = defaultPred.index.tolist()[:6]
 
     gene_feats = feature_df.loc[varIDs, feature_names].copy()

--- a/bin/extraModel/generate_bivar_data.py
+++ b/bin/extraModel/generate_bivar_data.py
@@ -110,7 +110,7 @@ def process_gene(param):
     seen_pairs = set() 
     
     allVars = feature_df.index.tolist()
-    varIDs = [v for v in varIDs if v in allVars]
+    varIDs = sorted([v for v in varIDs if v in allVars])
 
     if len(varIDs) == 0:
         return

--- a/bin/extraModel/integrate_output.py
+++ b/bin/extraModel/integrate_output.py
@@ -11,7 +11,7 @@ def process_recessive_matrix(df):
 
     result = []
     for _, var_grp in var_grps:
-        var_grp = var_grp.sort_index()
+        var_grp = var_grp.sort_values("var2", kind="stable")        
         var_grp = var_grp.sort_values("predict", ascending=False, kind="stable") 
         result.append(var_grp.iloc[[0], :])
     result = pd.concat(result)

--- a/bin/extraModel/integrate_output.py
+++ b/bin/extraModel/integrate_output.py
@@ -11,7 +11,8 @@ def process_recessive_matrix(df):
 
     result = []
     for _, var_grp in var_grps:
-        var_grp = var_grp.sort_values("predict", ascending=False)
+        var_grp = var_grp.sort_index()
+        var_grp = var_grp.sort_values("predict", ascending=False, kind="stable") 
         result.append(var_grp.iloc[[0], :])
     result = pd.concat(result)
     result.set_index("var1", inplace=True)
@@ -31,6 +32,7 @@ def integrate_output(prj_folder, data_folder, sample_id):
         expanded_df = pd.read_csv(
             expanded_fn, sep="\t", index_col=0, compression="infer"
         )
+    expanded_df = expanded_df.sort_index()
     # expanded_df.append(df)
     # expanded_df = pd.concat(expanded_df)
     # expanded_df = expanded_df.loc[~expanded_df.index.duplicated(keep='first')]

--- a/bin/extraModel_main.py
+++ b/bin/extraModel_main.py
@@ -57,7 +57,8 @@ def assign_ranking(df):
     return pred_df
 
 
-def AIM(data_folder, sample_id):
+# def AIM(data_folder, sample_id):
+def AIM(data_folder, sample_id, n_thread):
     feature_fn = f"{sample_id}.csv"
 
     if not os.path.exists(feature_fn):
@@ -89,7 +90,8 @@ def AIM(data_folder, sample_id):
         data_folder=out_folder,
         sample_id=sample_id,
         default_pred=default_pred,
-        labeling=False,
+        #labeling=False,
+        n_thread = n_thread
     )
 
     recessive_feature_file = f"{out_folder}/recessive_matrix/{sample_id}.csv"
@@ -122,4 +124,5 @@ def AIM(data_folder, sample_id):
 
 
 # for sample_id in tqdm(sample_folders):
-AIM(out_folder, sample_id)
+#AIM(out_folder, sample_id)
+AIM(out_folder, sample_id, n_thread = 10)

--- a/bin/extraModel_main.py
+++ b/bin/extraModel_main.py
@@ -104,8 +104,9 @@ def AIM(data_folder, sample_id):
                 df_pred.loc[:, model_dict[mn]["features"]]
             )[:, 1]
             df_pred.insert(loc=df_pred.shape[1] - 1, column="predict", value=predict)
+            df_pred = df_pred.sort_index()
             df_pred = assign_confidence_score(model_dict[mn]["ref"], df_pred)
-            df_pred = df_pred.sort_values("confidence", ascending=False)
+            df_pred = df_pred.sort_values("confidence", ascending=False, kind="stable")
             df_pred = assign_ranking(df_pred)
             df_pred.to_csv(f"{out_folder}/{sample_id}_{mn}_predictions.csv")
     else:

--- a/bin/extraModel_main.py
+++ b/bin/extraModel_main.py
@@ -57,8 +57,7 @@ def assign_ranking(df):
     return pred_df
 
 
-# def AIM(data_folder, sample_id):
-def AIM(data_folder, sample_id, n_thread):
+def AIM(data_folder, sample_id):
     feature_fn = f"{sample_id}.csv"
 
     if not os.path.exists(feature_fn):
@@ -90,8 +89,7 @@ def AIM(data_folder, sample_id, n_thread):
         data_folder=out_folder,
         sample_id=sample_id,
         default_pred=default_pred,
-        #labeling=False,
-        n_thread = n_thread
+        labeling=False,
     )
 
     recessive_feature_file = f"{out_folder}/recessive_matrix/{sample_id}.csv"
@@ -124,5 +122,4 @@ def AIM(data_folder, sample_id, n_thread):
 
 
 # for sample_id in tqdm(sample_folders):
-#AIM(out_folder, sample_id)
-AIM(out_folder, sample_id, n_thread = 10)
+AIM(out_folder, sample_id)

--- a/bin/fillna_tier.py
+++ b/bin/fillna_tier.py
@@ -98,6 +98,7 @@ def feature_engineering(score_file, tier_file):
     # patient = pd.read_csv(score_file,sep='\t')
     feature_stat = pd.read_csv("annotate/feature_stats.csv", index_col=0)
 
+
     patient = score_file.copy()
 
     patient = patient[variable_name]
@@ -199,7 +200,7 @@ def feature_engineering(score_file, tier_file):
             (pd.isna(patient["GERPpp_RS"])) & np.array(indel_index), "GERPpp_RS"
         ] = feature_stat.loc["GERPpp_RS", "mean"]
         patient.loc[pd.isna(patient["GERPpp_RS"]), "GERPpp_RS"] = feature_stat.loc[
-            "GERPpp_RS", "mean"
+            "GERPpp_RS", "min"
         ]
         patient["GERPpp_RS"] = patient["GERPpp_RS"].astype("float64")
     else:
@@ -210,7 +211,7 @@ def feature_engineering(score_file, tier_file):
         ] = patient["GERPpp_RS"].describe()["mean"]
         patient.loc[pd.isna(patient["GERPpp_RS"]), "GERPpp_RS"] = patient[
             "GERPpp_RS"
-        ].describe()["mean"]
+        ].describe()["min"]
 
     gnomadAFVal = patient["gnomadAF"].copy()
     gnomadAFVal = np.array([getValFromStr(str(i), "min") for i in gnomadAFVal])
@@ -249,7 +250,7 @@ def feature_engineering(score_file, tier_file):
             (pd.isna(patient["LRT_score"])) & np.array(indel_index), "LRT_score"
         ] = feature_stat.loc["LRT_score", "mean"]
         patient.loc[pd.isna(patient["LRT_score"]), "LRT_score"] = feature_stat.loc[
-            "LRT_score", "mean"
+            "LRT_score", "min"
         ]
         patient["LRT_score"] = patient["LRT_score"].astype("float64")
     else:
@@ -260,7 +261,7 @@ def feature_engineering(score_file, tier_file):
         ] = patient["LRT_score"].describe()["mean"]
         patient.loc[pd.isna(patient["LRT_score"]), "LRT_score"] = patient[
             "LRT_score"
-        ].describe()["mean"]
+        ].describe()["min"]
 
     patient.loc[patient["LRT_Omega"] == "-", "LRT_Omega"] = np.NaN
     if np.all(pd.isna(patient["LRT_Omega"])):
@@ -269,7 +270,7 @@ def feature_engineering(score_file, tier_file):
             (pd.isna(patient["LRT_Omega"])) & np.array(indel_index), "LRT_Omega"
         ] = feature_stat.loc["LRT_Omega", "mean"]
         patient.loc[pd.isna(patient["LRT_Omega"]), "LRT_Omega"] = feature_stat.loc[
-            "LRT_Omega", "mean"
+            "LRT_Omega", "min"
         ]
         patient["LRT_Omega"] = patient["LRT_Omega"].astype("float64")
     else:
@@ -280,7 +281,7 @@ def feature_engineering(score_file, tier_file):
         ] = patient["LRT_Omega"].describe()["mean"]
         patient.loc[pd.isna(patient["LRT_Omega"]), "LRT_Omega"] = patient[
             "LRT_Omega"
-        ].describe()["mean"]
+        ].describe()["min"]
 
     patient.loc[
         patient["phyloP100way_vertebrate"] == "-", "phyloP100way_vertebrate"
@@ -293,7 +294,7 @@ def feature_engineering(score_file, tier_file):
         ] = feature_stat.loc["phyloP100way_vertebrate", "mean"]
         patient.loc[
             pd.isna(patient["phyloP100way_vertebrate"]), "phyloP100way_vertebrate"
-        ] = feature_stat.loc["phyloP100way_vertebrate", "mean"]
+        ] = feature_stat.loc["phyloP100way_vertebrate", "min"]
         patient["phyloP100way_vertebrate"] = patient["phyloP100way_vertebrate"].astype(
             "float64"
         )
@@ -308,13 +309,13 @@ def feature_engineering(score_file, tier_file):
         ] = patient["phyloP100way_vertebrate"].describe()["mean"]
         patient.loc[
             pd.isna(patient["phyloP100way_vertebrate"]), "phyloP100way_vertebrate"
-        ] = patient["phyloP100way_vertebrate"].describe()["mean"]
+        ] = patient["phyloP100way_vertebrate"].describe()["min"]
 
     patient.loc[patient["gnomadGeneZscore"] == "-", "gnomadGeneZscore"] = np.NaN
     if np.all(pd.isna(patient["gnomadGeneZscore"])):
         # Single variant query
         patient.loc[pd.isna(patient["gnomadGeneZscore"]), "gnomadGeneZscore"] = (
-            feature_stat.loc["gnomadGeneZscore", "mean"]
+            feature_stat.loc["gnomadGeneZscore", "min"]
         )
         patient["gnomadGeneZscore"] = patient["gnomadGeneZscore"].astype("float64")
     else:
@@ -322,13 +323,13 @@ def feature_engineering(score_file, tier_file):
         patient["gnomadGeneZscore"] = patient["gnomadGeneZscore"].astype("float64")
         patient.loc[pd.isna(patient["gnomadGeneZscore"]), "gnomadGeneZscore"] = patient[
             "gnomadGeneZscore"
-        ].describe()["mean"]
+        ].describe()["min"]
 
     patient.loc[patient["gnomadGenePLI"] == "-", "gnomadGenePLI"] = np.NaN
     if np.all(pd.isna(patient["gnomadGenePLI"])):
         # Single variant query
         patient.loc[pd.isna(patient["gnomadGenePLI"]), "gnomadGenePLI"] = (
-            feature_stat.loc["gnomadGenePLI", "mean"]
+            feature_stat.loc["gnomadGenePLI", "min"]
         )
         patient["gnomadGenePLI"] = patient["gnomadGenePLI"].astype("float64")
     else:
@@ -336,13 +337,13 @@ def feature_engineering(score_file, tier_file):
         patient["gnomadGenePLI"] = patient["gnomadGenePLI"].astype("float64")
         patient.loc[pd.isna(patient["gnomadGenePLI"]), "gnomadGenePLI"] = patient[
             "gnomadGenePLI"
-        ].describe()["mean"]
+        ].describe()["min"]
 
     patient.loc[patient["gnomadGeneOELof"] == "-", "gnomadGeneOELof"] = np.NaN
     if np.all(pd.isna(patient["gnomadGeneOELof"])):
         # Single variant query
         patient.loc[pd.isna(patient["gnomadGeneOELof"]), "gnomadGeneOELof"] = (
-            feature_stat.loc["gnomadGeneOELof", "mean"]
+            feature_stat.loc["gnomadGeneOELof", "max"]
         )
         patient["gnomadGeneOELof"] = patient["gnomadGeneOELof"].astype("float64")
     else:
@@ -350,14 +351,14 @@ def feature_engineering(score_file, tier_file):
         patient["gnomadGeneOELof"] = patient["gnomadGeneOELof"].astype("float64")
         patient.loc[pd.isna(patient["gnomadGeneOELof"]), "gnomadGeneOELof"] = patient[
             "gnomadGeneOELof"
-        ].describe()["mean"]
+        ].describe()["max"]
 
     patient.loc[patient["gnomadGeneOELofUpper"] == "-", "gnomadGeneOELofUpper"] = np.NaN
     if np.all(pd.isna(patient["gnomadGeneOELofUpper"])):
         # Single variant query
         patient.loc[
             pd.isna(patient["gnomadGeneOELofUpper"]), "gnomadGeneOELofUpper"
-        ] = feature_stat.loc["gnomadGeneOELofUpper", "mean"]
+        ] = feature_stat.loc["gnomadGeneOELofUpper", "max"]
         patient["gnomadGeneOELofUpper"] = patient["gnomadGeneOELofUpper"].astype(
             "float64"
         )
@@ -368,7 +369,7 @@ def feature_engineering(score_file, tier_file):
         )
         patient.loc[
             pd.isna(patient["gnomadGeneOELofUpper"]), "gnomadGeneOELofUpper"
-        ] = patient["gnomadGeneOELofUpper"].describe()["mean"]
+        ] = patient["gnomadGeneOELofUpper"].describe()["max"]
 
     patient.loc[patient["IMPACT"] == "-", "IMPACT"] = 0
     patient.loc[patient["IMPACT"] == "MODIFIER", "IMPACT"] = 1
@@ -385,7 +386,7 @@ def feature_engineering(score_file, tier_file):
             (pd.isna(patient["CADD_phred"])) & np.array(indel_index), "CADD_phred"
         ] = feature_stat.loc["CADD_phred", "mean"]
         patient.loc[pd.isna(patient["CADD_phred"]), "CADD_phred"] = feature_stat.loc[
-            "CADD_phred", "mean"
+            "CADD_phred", "min"
         ]
         patient["CADD_phred"] = patient["CADD_phred"].astype("float64")
     else:
@@ -396,7 +397,7 @@ def feature_engineering(score_file, tier_file):
         ] = patient["CADD_phred"].describe()["mean"]
         patient.loc[pd.isna(patient["CADD_phred"]), "CADD_phred"] = patient[
             "CADD_phred"
-        ].describe()["mean"]
+        ].describe()["min"]
 
     patient.loc[patient["CADD_PHRED"] == "-", "CADD_PHRED"] = np.NaN
     if np.all(pd.isna(patient["CADD_PHRED"])):
@@ -405,7 +406,7 @@ def feature_engineering(score_file, tier_file):
             (pd.isna(patient["CADD_PHRED"])) & np.array(indel_index), "CADD_PHRED"
         ] = feature_stat.loc["CADD_PHRED", "mean"]
         patient.loc[pd.isna(patient["CADD_PHRED"]), "CADD_PHRED"] = feature_stat.loc[
-            "CADD_PHRED", "mean"
+            "CADD_PHRED", "min"
         ]
         patient["CADD_PHRED"] = patient["CADD_PHRED"].astype("float64")
     else:
@@ -416,7 +417,7 @@ def feature_engineering(score_file, tier_file):
         ] = patient["CADD_PHRED"].describe()["mean"]
         patient.loc[pd.isna(patient["CADD_PHRED"]), "CADD_PHRED"] = patient[
             "CADD_PHRED"
-        ].describe()["mean"]
+        ].describe()["min"]
 
     # DANN_score
     patient.loc[patient["DANN_score"] == "-", "DANN_score"] = np.NaN
@@ -426,7 +427,7 @@ def feature_engineering(score_file, tier_file):
             (pd.isna(patient["DANN_score"])) & np.array(indel_index), "DANN_score"
         ] = feature_stat.loc["DANN_score", "mean"]
         patient.loc[pd.isna(patient["DANN_score"]), "DANN_score"] = feature_stat.loc[
-            "DANN_score", "mean"
+            "DANN_score", "min"
         ]
         patient["DANN_score"] = patient["DANN_score"].astype("float64")
     else:
@@ -437,13 +438,12 @@ def feature_engineering(score_file, tier_file):
         ] = patient["DANN_score"].describe()["mean"]
         patient.loc[pd.isna(patient["DANN_score"]), "DANN_score"] = patient[
             "DANN_score"
-        ].describe()["mean"]
+        ].describe()["min"]
 
     # REVEL_score
-    # patient['Polyphen2_HDIV_score'] = patient['Polyphen2_HDIV_score'] #.str.split(',')
     patient.loc[patient["REVEL_score"] == "-", "REVEL_score"] = np.NaN
     for i in patient[~patient["REVEL_score"].isna()].index:
-        score_list = patient.loc[i, "REVEL_score"].split(",")
+        score_list = str(patient.loc[i, "REVEL_score"]).split(",")
         score_list = [float(i) for i in score_list if i != "-" and i != "."]
         if score_list == []:
             patient.loc[i, "REVEL_score"] = np.NaN
@@ -456,7 +456,7 @@ def feature_engineering(score_file, tier_file):
             (pd.isna(patient["REVEL_score"])) & np.array(indel_index), "REVEL_score"
         ] = feature_stat.loc["REVEL_score", "mean"]
         patient.loc[pd.isna(patient["REVEL_score"]), "REVEL_score"] = feature_stat.loc[
-            "REVEL_score", "mean"
+            "REVEL_score", "min"
         ]
         patient["REVEL_score"] = patient["REVEL_score"].astype("float64")
     else:
@@ -467,7 +467,7 @@ def feature_engineering(score_file, tier_file):
         ] = patient["REVEL_score"].describe()["mean"]
         patient.loc[pd.isna(patient["REVEL_score"]), "REVEL_score"] = patient[
             "REVEL_score"
-        ].describe()["mean"]
+        ].describe()["min"]
 
     # fathmm_MKL_coding_score
     patient.loc[
@@ -481,7 +481,7 @@ def feature_engineering(score_file, tier_file):
         ] = feature_stat.loc["fathmm_MKL_coding_score", "mean"]
         patient.loc[
             pd.isna(patient["fathmm_MKL_coding_score"]), "fathmm_MKL_coding_score"
-        ] = feature_stat.loc["fathmm_MKL_coding_score", "mean"]
+        ] = feature_stat.loc["fathmm_MKL_coding_score", "min"]
         patient["fathmm_MKL_coding_score"] = patient["fathmm_MKL_coding_score"].astype(
             "float64"
         )
@@ -496,7 +496,7 @@ def feature_engineering(score_file, tier_file):
         ] = patient["fathmm_MKL_coding_score"].describe()["mean"]
         patient.loc[
             pd.isna(patient["fathmm_MKL_coding_score"]), "fathmm_MKL_coding_score"
-        ] = patient["fathmm_MKL_coding_score"].describe()["mean"]
+        ] = patient["fathmm_MKL_coding_score"].describe()["min"]
 
     # conservationScoreGnomad
     patient.loc[
@@ -525,10 +525,10 @@ def feature_engineering(score_file, tier_file):
     )
 
     # Polyphen2_HDIV_score
-    patient["Polyphen2_HDIV_score"] = patient["Polyphen2_HDIV_score"]  # .str.split(',')
+    patient["Polyphen2_HDIV_score"] = patient["Polyphen2_HDIV_score"]
     patient.loc[patient["Polyphen2_HDIV_score"] == "-", "Polyphen2_HDIV_score"] = np.NaN
     for i in patient[~patient["Polyphen2_HDIV_score"].isna()].index:
-        score_list = patient.loc[i, "Polyphen2_HDIV_score"].split(",")
+        score_list = str(patient.loc[i, "Polyphen2_HDIV_score"]).split(",")
         score_list = [float(i) for i in score_list if i != "-" and i != "."]
         if score_list == []:
             patient.loc[i, "Polyphen2_HDIV_score"] = np.NaN
@@ -543,7 +543,7 @@ def feature_engineering(score_file, tier_file):
         ] = feature_stat.loc["Polyphen2_HDIV_score", "50%"]
         patient.loc[
             pd.isna(patient["Polyphen2_HDIV_score"]), "Polyphen2_HDIV_score"
-        ] = feature_stat.loc["Polyphen2_HDIV_score", "50%"]
+        ] = feature_stat.loc["Polyphen2_HDIV_score", "min"]
         patient["Polyphen2_HDIV_score"] = patient["Polyphen2_HDIV_score"].astype(
             "float64"
         )
@@ -558,13 +558,13 @@ def feature_engineering(score_file, tier_file):
         ] = patient["Polyphen2_HDIV_score"].describe()["50%"]
         patient.loc[
             pd.isna(patient["Polyphen2_HDIV_score"]), "Polyphen2_HDIV_score"
-        ] = patient["Polyphen2_HDIV_score"].describe()["50%"]
+        ] = patient["Polyphen2_HDIV_score"].describe()["min"]
 
     # Polyphen2_HVAR_score
-    patient["Polyphen2_HVAR_score"] = patient["Polyphen2_HVAR_score"]  # .str.split(',')
+    patient["Polyphen2_HVAR_score"] = patient["Polyphen2_HVAR_score"]
     patient.loc[patient["Polyphen2_HVAR_score"] == "-", "Polyphen2_HVAR_score"] = np.NaN
     for i in patient[~patient["Polyphen2_HVAR_score"].isna()].index:
-        score_list = patient.loc[i, "Polyphen2_HVAR_score"].split(",")
+        score_list = str(patient.loc[i, "Polyphen2_HVAR_score"]).split(",")
         score_list = [float(i) for i in score_list if i != "-" and i != "."]
         if score_list == []:
             patient.loc[i, "Polyphen2_HVAR_score"] = np.NaN
@@ -579,7 +579,7 @@ def feature_engineering(score_file, tier_file):
         ] = feature_stat.loc["Polyphen2_HVAR_score", "50%"]
         patient.loc[
             pd.isna(patient["Polyphen2_HVAR_score"]), "Polyphen2_HVAR_score"
-        ] = feature_stat.loc["Polyphen2_HVAR_score", "50%"]
+        ] = feature_stat.loc["Polyphen2_HVAR_score", "min"]
         patient["Polyphen2_HVAR_score"] = patient["Polyphen2_HVAR_score"].astype(
             "float64"
         )
@@ -594,13 +594,13 @@ def feature_engineering(score_file, tier_file):
         ] = patient["Polyphen2_HVAR_score"].describe()["50%"]
         patient.loc[
             pd.isna(patient["Polyphen2_HVAR_score"]), "Polyphen2_HVAR_score"
-        ] = patient["Polyphen2_HVAR_score"].describe()["50%"]
+        ] = patient["Polyphen2_HVAR_score"].describe()["min"]
 
     # SIFT_score
-    patient["SIFT_score"] = patient["SIFT_score"]  # .str.split(',')
+    patient["SIFT_score"] = patient["SIFT_score"]
     patient.loc[patient["SIFT_score"] == "-", "SIFT_score"] = np.NaN
     for i in patient[~patient["SIFT_score"].isna()].index:
-        score_list = patient.loc[i, "SIFT_score"].split(",")
+        score_list = str(patient.loc[i, "SIFT_score"]).split(",")
         score_list = [float(i) for i in score_list if i != "-" and i != "."]
         if score_list == []:
             patient.loc[i, "SIFT_score"] = np.NaN
@@ -613,7 +613,7 @@ def feature_engineering(score_file, tier_file):
             (pd.isna(patient["SIFT_score"])) & np.array(indel_index), "SIFT_score"
         ] = feature_stat.loc["SIFT_score", "50%"]
         patient.loc[pd.isna(patient["SIFT_score"]), "SIFT_score"] = feature_stat.loc[
-            "SIFT_score", "50%"
+            "SIFT_score", "max"
         ]
         patient["SIFT_score"] = patient["SIFT_score"].astype("float64")
     else:
@@ -624,7 +624,7 @@ def feature_engineering(score_file, tier_file):
         ] = patient["SIFT_score"].describe()["50%"]
         patient.loc[pd.isna(patient["SIFT_score"]), "SIFT_score"] = patient[
             "SIFT_score"
-        ].describe()["50%"]
+        ].describe()["max"]
 
     patient.loc[patient["zyg"] == "HET", "zyg"] = 1
     patient.loc[patient["zyg"] == "HOM", "zyg"] = 2
@@ -638,10 +638,10 @@ def feature_engineering(score_file, tier_file):
     # patient.loc[pd.isna(patient['GERPpp_NR']), 'GERPpp_NR'] = patient['GERPpp_NR'].describe()['min']
 
     # FATHMM_score
-    patient["FATHMM_score"] = patient["FATHMM_score"]  # .str.split(',')
+    patient["FATHMM_score"] = patient["FATHMM_score"]
     patient.loc[patient["FATHMM_score"] == "-", "FATHMM_score"] = np.NaN
     for i in patient[~patient["FATHMM_score"].isna()].index:
-        score_list = patient.loc[i, "FATHMM_score"].split(",")
+        score_list = str(patient.loc[i, "FATHMM_score"]).split(",")
         score_list = [float(i) for i in score_list if i != "-" and i != "."]
         if score_list == []:
             patient.loc[i, "FATHMM_score"] = np.NaN
@@ -654,7 +654,7 @@ def feature_engineering(score_file, tier_file):
             (pd.isna(patient["FATHMM_score"])) & np.array(indel_index), "FATHMM_score"
         ] = feature_stat.loc["FATHMM_score", "50%"]
         patient.loc[pd.isna(patient["FATHMM_score"]), "FATHMM_score"] = (
-            feature_stat.loc["FATHMM_score", "50%"]
+            feature_stat.loc["FATHMM_score", "max"]
         )
         patient["FATHMM_score"] = patient["FATHMM_score"].astype("float64")
     else:
@@ -665,7 +665,7 @@ def feature_engineering(score_file, tier_file):
         ] = patient["FATHMM_score"].describe()["50%"]
         patient.loc[pd.isna(patient["FATHMM_score"]), "FATHMM_score"] = patient[
             "FATHMM_score"
-        ].describe()["50%"]
+        ].describe()["max"]
 
     # M_CAP_score
     patient.loc[patient["M_CAP_score"] == "-", "M_CAP_score"] = np.NaN
@@ -675,7 +675,7 @@ def feature_engineering(score_file, tier_file):
             (pd.isna(patient["M_CAP_score"])) & np.array(indel_index), "M_CAP_score"
         ] = feature_stat.loc["M_CAP_score", "mean"]
         patient.loc[pd.isna(patient["M_CAP_score"]), "M_CAP_score"] = feature_stat.loc[
-            "M_CAP_score", "mean"
+            "M_CAP_score", "min"
         ]
         patient["M_CAP_score"] = patient["M_CAP_score"].astype("float64")
     else:
@@ -686,17 +686,15 @@ def feature_engineering(score_file, tier_file):
         ] = patient["M_CAP_score"].describe()["mean"]
         patient.loc[pd.isna(patient["M_CAP_score"]), "M_CAP_score"] = patient[
             "M_CAP_score"
-        ].describe()["mean"]
+        ].describe()["min"]
 
     # MutationAssessor_score
-    patient["MutationAssessor_score"] = patient[
-        "MutationAssessor_score"
-    ]  # .str.split(',')
+    patient["MutationAssessor_score"] = patient["MutationAssessor_score"]
     patient.loc[patient["MutationAssessor_score"] == "-", "MutationAssessor_score"] = (
         np.NaN
     )
     for i in patient[~patient["MutationAssessor_score"].isna()].index:
-        score_list = patient.loc[i, "MutationAssessor_score"].split(",")
+        score_list = str(patient.loc[i, "MutationAssessor_score"]).split(",")
         score_list = [float(i) for i in score_list if i != "-" and i != "."]
         if score_list == []:
             patient.loc[i, "MutationAssessor_score"] = np.NaN
@@ -711,7 +709,7 @@ def feature_engineering(score_file, tier_file):
         ] = feature_stat.loc["MutationAssessor_score", "50%"]
         patient.loc[
             pd.isna(patient["MutationAssessor_score"]), "MutationAssessor_score"
-        ] = feature_stat.loc["MutationAssessor_score", "50%"]
+        ] = feature_stat.loc["MutationAssessor_score", "min"]
         patient["MutationAssessor_score"] = patient["MutationAssessor_score"].astype(
             "float64"
         )
@@ -726,20 +724,20 @@ def feature_engineering(score_file, tier_file):
         ] = patient["MutationAssessor_score"].describe()["50%"]
         patient.loc[
             pd.isna(patient["MutationAssessor_score"]), "MutationAssessor_score"
-        ] = patient["MutationAssessor_score"].describe()["50%"]
+        ] = patient["MutationAssessor_score"].describe()["min"]
 
     # ESP6500_AA_AF
     patient.loc[patient["ESP6500_AA_AF"] == "-", "ESP6500_AA_AF"] = 0.0
     patient["ESP6500_AA_AF"] = patient["ESP6500_AA_AF"].astype("float64")
 
-    # ESP6500_AA_AF
+    # ESP6500_EA_AF
     patient.loc[patient["ESP6500_EA_AF"] == "-", "ESP6500_EA_AF"] = 0.0
     patient["ESP6500_EA_AF"] = patient["ESP6500_EA_AF"].astype("float64")
 
     # hom
     patient.loc[patient["hom"] == "-", "hom"] = np.NaN
     for i in patient[~patient["hom"].isna()].index:
-        score_list = patient.loc[i, "hom"].split(",")
+        score_list = str(patient.loc[i, "hom"]).split(",")
         score_list = [float(i) for i in score_list if i != "-" and i != "."]
         if score_list == []:
             patient.loc[i, "hom"] = np.NaN
@@ -761,7 +759,7 @@ def feature_engineering(score_file, tier_file):
     if np.all(pd.isna(patient["spliceAImax"])):
         # Single variant query
         patient.loc[pd.isna(patient["spliceAImax"]), "spliceAImax"] = feature_stat.loc[
-            "spliceAImax", "mean"
+            "spliceAImax", "min"
         ]
         patient["spliceAImax"] = patient["spliceAImax"].astype("float64")
     else:
@@ -769,7 +767,7 @@ def feature_engineering(score_file, tier_file):
         patient["spliceAImax"] = patient["spliceAImax"].astype("float64")
         patient.loc[pd.isna(patient["spliceAImax"]), "spliceAImax"] = patient.loc[
             ~pd.isna(patient["spliceAImax"]), "spliceAImax"
-        ].describe()["mean"]
+        ].describe()["min"]
 
     # Consequence
     consequence = [

--- a/bin/generate_new_matrix_2.py
+++ b/bin/generate_new_matrix_2.py
@@ -32,7 +32,7 @@ else:
 merged["varId"] = merged["varId"].apply(lambda x: x.split("_E")[0])
 
 ### read tier ###
-tier_f = pd.read_csv("Tier.v2.tsv", sep="\t")
+tier_f = pd.read_csv("Tier.v2.tsv", sep="\t").sort_index()
 
 ### add phrank calculated elsewhere for final combination ###
 if phrank_empty:

--- a/main.nf
+++ b/main.nf
@@ -375,7 +375,7 @@ workflow {
     INDEX_VCF(params.input_vcf)
     VCF_PRE_PROCESS(INDEX_VCF.out, params.chrmap)
 
-    ANNOT_PHRANK(VCF_PRE_PROCESS.out)
+    ANNOT_PHRANK(INDEX_VCF.out[0])
     ANNOT_ENSMBLE(ANNOT_PHRANK.out, params.ref_loc)
     TO_GENE_SYM(ANNOT_ENSMBLE.out, params.ref_to_sym, params.ref_sorted_sym)
     PHRANK_SCORING( TO_GENE_SYM.out, 


### PR DESCRIPTION
This version has been modified version of `nextflow_conversion` to match the output of the [`main_fix_sort`](https://github.com/hyunhwan-bcm/AI_MARRVEL/tree/main_fix_sort) branch. Both branches now use stable sorting for almost 100% of its sorts. Additionally, the comparisons are identical after sorting the integrated output, with a precision error margin of 1e-9.

There are a couple of things to note:

1. The `add_n_c.py` script still has the issue of not merging the clin_var profile, but we can fix it once the other fixes produce the same result as `main_fix_sort`.
2. The `phrank` input needs to be changed - the current version receives an unfiltered VCF.
3. The `generate_*.py` scripts were reverted, and we need to ensure that the versions in `nextflow_conversion` can generate identical files.

